### PR TITLE
Reproducing @wordpress/dataviews build failure using pnpm with hoisting disabled

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# No hoisting by default.
+hoist-pattern=[]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "wp-scripts start"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.26.0",
     "@wordpress/scripts": "^30.6.2-next.cd6172eb0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This is to reproduce the bug in Gutenberg

- https://github.com/WordPress/gutenberg/issues/67864

Steps:

- Checkout the PR
- Run `pnpm install`
- Run `pnpm run build`
- See the error