### PR TITLE
Add Dependabot config, auto-approve, and auto-merge workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration for a JavaScript/npm project
+# Based on the WP Training Team Dependabot guide (Example 2).
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"              # location of package.json
+    schedule:
+      interval: "weekly"        # or "daily", "monthly"
+    assignees:
+      - "jonathanbossenger"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-approve
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Only run for PRs opened by Dependabot
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Only run for PRs opened by Dependabot
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge changes from Dependabot
+        # Auto-merge all non-major updates, and all GitHub Actions updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major' || steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Process according to Training handbook page [Setting Up Dependabot for WP Training Team repositories](https://make.wordpress.org/training/handbook/training-team-how-to-guides/setting-up-dependabot-for-wp-training-team-repositories/#example-3-both-npm-and-composer-dependencies)

Branch protection rules uploaded.